### PR TITLE
Add support for 390.x driver and refactor existing code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,32 @@
 CC            = gcc
 CFLAGS        =
-TARGET_VER    = 325.15# just set to a valid ver eg. one of:  325.08 325.15 319.32 319.23
+# just set TARGET_VER to a valid ver eg. one of:  390.48 325.08 325.15 319.32 319.23
+TARGET_VER    = 390.48
 TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . --f=1)
 TARGET        = libnvidia-ml.so.1
-DESTDIR       = /
-PREFIX        = $(DESTDIR)usr
-libdir        = $(PREFIX)/lib
+# change libdir below based on where libnvidia-ml.so.1 resides.
+# some common values are: /usr/lib, /usr/lib64, /usr/lib/i386-linux-gnu, /usr/lib/x86_64-linux-gnu
+libdir        = /usr/lib/x86_64-linux-gnu
 INSTALL       = /usr/bin/install -D
 
-all: $(TARGET)
+.PHONY: check_supported clean install all
+
+all: check_supported $(TARGET)
+
+check_supported:
+ifeq ($(TARGET_MAJOR),319)
+else ifeq ($(TARGET_MAJOR),325)
+else ifeq ($(TARGET_MAJOR),331)
+else ifeq ($(TARGET_MAJOR),390)
+else
+	$(error Driver major version $(TARGET_MAJOR) is not supported!)
+endif
 
 ${TARGET:1=${TARGET_VER}}: empty.c 
-	${CC} ${CFLAGS} -shared -fPIC $(<) -o $(@) 
+	${CC} ${CFLAGS} -shared -fPIC -s $(<) -o $(@) 
 
 $(TARGET): ${TARGET:1=${TARGET_VER}}
-	${CC} ${CFLAGS} -shared -fPIC -o $(@) -DNVML_PATCH_${TARGET_MAJOR} -DNVML_VERSION=\"$(TARGET_VER)\" $< nvml_fix.c
-
+	${CC} ${CFLAGS} -Wl,--no-as-needed -shared -fPIC -s -o $(@) -DNVML_PATCH_${TARGET_MAJOR} -DNVML_VERSION=\"$(TARGET_VER)\" $< nvml_fix.c
 
 clean: 
 	rm -f $(TARGET)
@@ -24,4 +35,3 @@ clean:
 install: libnvidia-ml.so.1
 	$(INSTALL) -Dm755 $(^) $(libdir)/$(^)
 
-.PHONY: clean install all


### PR DESCRIPTION
This adds support for 390.x which required significant changes due to
using nvmlInitWithFlags(unsigned int flags), whereas the previous
nvmlInit() functions did not require passing any parameters. Effort was
made to keep backwards compatibility (e.g. with 331 and below) by using
a large amount of #if/#elif throughout nvml_fix.c. However, the old
versions have not been tested beyond verifying they compile.

Also, the Makefile now checks if a supported TARGET_VERSION was provided
before attempting any compilation. Without this change, the #error from
nvml_fix.c is lost in a wall of other errors due to the refactoring. The
make target is named "check_supported" and is called by default.

For the time being, only the offsets for x86_64 have been added.

Other changes:

- ${CC} is now called with "-s" which strips the library during the
compilation step

- ${CC} is now called with "-Wl,--no-as-needed", which is required on
newer gcc/binutils versions due to "--as-needed" being the new default

- the DESTDIR and prefix variables were removed in favor of a single
libdir variable for clarity

- instead of bundling the nvml.h header from 390.x, it is now pulled in
from the default system-wide header include path

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>