### PR TITLE
Add support for 410.x driver series

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC            = gcc
 CFLAGS        =
 # just set TARGET_VER to a valid ver eg. one of:  390.48 325.08 325.15 319.32 319.23
-TARGET_VER    = 396.54
+TARGET_VER    = 410.73
 TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . --f=1)
 TARGET        = libnvidia-ml.so.1
 # change libdir below based on where libnvidia-ml.so.1 resides.
@@ -19,6 +19,7 @@ else ifeq ($(TARGET_MAJOR),325)
 else ifeq ($(TARGET_MAJOR),331)
 else ifeq ($(TARGET_MAJOR),390)
 else ifeq ($(TARGET_MAJOR),396)
+else ifeq ($(TARGET_MAJOR),410)
 else
 	$(error Driver major version $(TARGET_MAJOR) is not supported!)
 endif

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ the device is in fact supported, and returns information properly.
 How to use
 ----------
 The Makefile can be used to build shims for a given NVML version with `make TARGET_VER=major.minor`.
-The full *major.minor* value must be specified, so `TARGET_VER=390` isn't sufficient, but
-`TARGET_VER=396.54` is:  
-  * `make TARGET_VER=396.54`
+The full *major.minor* value must be specified, so `TARGET_VER=410` isn't sufficient, but
+`TARGET_VER=410.73` is:
+  * `make TARGET_VER=410.73`
 
-Currently supported versions are: 396.x (x86_64 only), 390.x (x86_64 only), 331.x (x86_64 only), 325.x,
-and 319.x, with the latest being the default.
+Currently supported versions are: 410.x (x86_64 only), 396.x (x86_64 only), 390.x (x86_64 only), 331.x
+(x86_64 only), 325.x, and 319.x, with the latest being the default.
 
 To install, delete the `libnvidia-ml.so.1` symlink currently in your `libdir` and run
 `make install libdir=/path/to/lib`:  
@@ -41,7 +41,7 @@ On Debian-based distros an alternative to deleting the symlink is to use `dpkg-d
   * `sudo dpkg-divert --add --local --divert /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1.orig --rename
 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1`
 
-The current Makefile defaults are `TARGET_VER=396.54 libdir=/usr/lib/x86_64-linux-gnu`.
+The current Makefile defaults are `TARGET_VER=410.73 libdir=/usr/lib/x86_64-linux-gnu`.
 
 If you are on a 64-bit system, you can build 32-bit versions with `make CFLAGS=-m32`.
 

--- a/nvml_fix.c
+++ b/nvml_fix.c
@@ -2,10 +2,10 @@
 
 #if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
 #include "nvml.h"
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396)
+#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410)
 #include <nvml.h>
 #else
-#error "No valid NVML_PATCH_* option specified! Currently supported versions are: 319, 325, 331 (x86_64 only), 390 (x86_64 only), 396 (x86_64 only)."
+#error "No valid NVML_PATCH_* option specified! Currently supported versions are: 319, 325, 331 (x86_64 only), 390 (x86_64 only), 396 (x86_64 only), 410 (x86_64 only)."
 #endif
 
 #define FUNC(f) static typeof(f) * real_##f;
@@ -15,7 +15,7 @@
 FUNC(nvmlInit)
 FUNC(nvmlDeviceGetHandleByIndex)
 FUNC(nvmlDeviceGetHandleByPciBusId)
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396)
+#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410)
 FUNC(nvmlInitWithFlags);
 #endif
 FUNC_v2(nvmlInit)
@@ -41,7 +41,7 @@ FUNC_v2(nvmlDeviceGetHandleByPciBusId)
 \
 	return real_##name(); \
 }
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396)
+#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410)
 #define INIT(name) nvmlReturn_t name() \
 { \
 void *nvml = dlopen("libnvidia-ml.so." NVML_VERSION, RTLD_NOW); \
@@ -62,7 +62,7 @@ INIT(nvmlInit)
 #endif
 INIT(nvmlInit_v2)
 
-#if defined(NVML_PATCH_390) || defined(NVML_PATCH_396)
+#if defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410)
 nvmlReturn_t nvmlInitWithFlags(unsigned int flags) {
 	void *nvml = dlopen("libnvidia-ml.so." NVML_VERSION, RTLD_NOW);
 
@@ -101,6 +101,13 @@ void fix_unsupported_bug(nvmlDevice_t device)
 # else
 	fix[352] = 1;
 	fix[353] = 1;
+# endif
+#elif defined(NVML_PATCH_410)
+# ifdef __i386__
+#  error "No i386 support for this version yet!"
+# else
+	fix[362] = 1;
+	fix[363] = 1;
 # endif
 #endif
 }


### PR DESCRIPTION
This adds offsets for the 410.x series, which is superseding 390.x as
NVIDIA's new long-lived branch.

The default TARGET_VER has been changed to 410.73, the latest 410.x
driver currently available in Ubuntu's "graphics-drivers" PPA.

As is the case with the last few supported major versions, only
offsets for x86_64 have been added.

Tested on Ubuntu 18.10 (amd64) with a GeForce GTX 650 Ti.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>