### PR TITLE
Clarity improvements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,30 +23,33 @@ How to use
 ----------
 The Makefile can be used to build shims for a given NVML version with `make TARGET_VER=major.minor`.
 The full *major.minor* value must be specified, so `TARGET_VER=410` isn't sufficient, but
-`TARGET_VER=410.73` is:
+`TARGET_VER=410.73` is:  
   * `make TARGET_VER=410.73`
 
 Currently supported versions are: 410.x (x86_64 only), 396.x (x86_64 only), 390.x (x86_64 only), 331.x
-(x86_64 only), 325.x, and 319.x, with the latest being the default.
+(x86_64 only), 325.x, and 319.x, with the latest being the default.  
 
 To install, delete the `libnvidia-ml.so.1` symlink currently in your `libdir` and run
 `make install libdir=/path/to/lib`:  
-  * `make install libdir=/usr/lib/x86_64-linux-gnu`
+  * `sudo make install TARGET_VER=410.73 libdir=/usr/lib/x86_64-linux-gnu`
+
+It is necessary to supply `TARGET_VER` during *both* `make` and `make install` if not using the default
+version.  
 
 Some common values for `libdir` are `/usr/lib`, `/usr/lib64` (32-bit and 64-bit rpm-based distros),
-`/usr/lib/i386-linux-gnu`, and `/usr/lib/x86_64-linux-gnu` (32-bit and 64-bit deb-based distros).
+`/usr/lib/i386-linux-gnu`, and `/usr/lib/x86_64-linux-gnu` (32-bit and 64-bit deb-based distros).  
 
 On Debian-based distros an alternative to deleting the symlink is to use `dpkg-divert` to rename it
 (before running `make install`):  
   * `sudo dpkg-divert --add --local --divert /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1.orig --rename
 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1`
 
-The current Makefile defaults are `TARGET_VER=410.73 libdir=/usr/lib/x86_64-linux-gnu`.
+The current Makefile defaults are `TARGET_VER=410.73 libdir=/usr/lib/x86_64-linux-gnu`.  
 
-If you are on a 64-bit system, you can build 32-bit versions with `make CFLAGS=-m32`.
+If you are on a 64-bit system, you can build 32-bit versions with `make CFLAGS=-m32`.  
 
 Note: The nVidia drivers are not a dependency for building the shims, but for 390.x and above the
-`nvml.h` header *must be installed* in gcc's include search path.
+`nvml.h` header *must be installed* in gcc's include search path.  
 
 Legal
 =====


### PR DESCRIPTION
Clarify the installation procedure and add some explicit newlines to
ensure markdown renders properly.