### PR TITLE
Bump to 410.104

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC            = gcc
 CFLAGS        =
 # just set TARGET_VER to a valid ver eg. one of:  390.48 325.08 325.15 319.32 319.23
-TARGET_VER    = 410.73
-TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . --f=1)
+TARGET_VER    = 410.104
+TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . -f 1)
 TARGET        = libnvidia-ml.so.1
 # change libdir below based on where libnvidia-ml.so.1 resides.
 # some common values are: /usr/lib, /usr/lib64, /usr/lib/i386-linux-gnu, /usr/lib/x86_64-linux-gnu

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ How to use
 ----------
 The Makefile can be used to build shims for a given NVML version with `make TARGET_VER=major.minor`.
 The full *major.minor* value must be specified, so `TARGET_VER=410` isn't sufficient, but
-`TARGET_VER=410.73` is:  
-  * `make TARGET_VER=410.73`
+`TARGET_VER=410.104` is:  
+  * `make TARGET_VER=410.104`  
 
 Currently supported versions are: 410.x (x86_64 only), 396.x (x86_64 only), 390.x (x86_64 only), 331.x
 (x86_64 only), 325.x, and 319.x, with the latest being the default.  
 
 To install, delete the `libnvidia-ml.so.1` symlink currently in your `libdir` and run
 `make install libdir=/path/to/lib`:  
-  * `sudo make install TARGET_VER=410.73 libdir=/usr/lib/x86_64-linux-gnu`
+  * `sudo make install TARGET_VER=410.104 libdir=/usr/lib/x86_64-linux-gnu`  
 
 It is necessary to supply `TARGET_VER` during *both* `make` and `make install` if not using the default
 version.  
@@ -42,9 +42,9 @@ Some common values for `libdir` are `/usr/lib`, `/usr/lib64` (32-bit and 64-bit 
 On Debian-based distros an alternative to deleting the symlink is to use `dpkg-divert` to rename it
 (before running `make install`):  
   * `sudo dpkg-divert --add --local --divert /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1.orig --rename
-/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1`
+/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1`  
 
-The current Makefile defaults are `TARGET_VER=410.73 libdir=/usr/lib/x86_64-linux-gnu`.  
+The current Makefile defaults are `TARGET_VER=410.104 libdir=/usr/lib/x86_64-linux-gnu`.  
 
 If you are on a 64-bit system, you can build 32-bit versions with `make CFLAGS=-m32`.  
 


### PR DESCRIPTION
The upstream 410.104 drivers contain important security fixes.

Offsets have stayed the same.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>