### PR TITLE
Add support for 450.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC            = gcc
 CFLAGS        =
 # just set TARGET_VER to a valid ver eg. one of:  390.48 325.08 325.15 319.32 319.23
-TARGET_VER    = 440.82
+TARGET_VER    = 450.57
 TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . -f 1)
 TARGET        = libnvidia-ml.so.1
 # change libdir below based on where libnvidia-ml.so.1 resides.
@@ -24,6 +24,7 @@ else ifeq ($(TARGET_MAJOR),415)
 else ifeq ($(TARGET_MAJOR),418)
 else ifeq ($(TARGET_MAJOR),430)
 else ifeq ($(TARGET_MAJOR),440)
+else ifeq ($(TARGET_MAJOR),450)
 else
 	$(error Driver major version $(TARGET_MAJOR) is not supported!)
 endif
@@ -38,6 +39,6 @@ clean:
 	rm -f $(TARGET)
 	rm -f ${TARGET:1=${TARGET_VER}}
 
-install: libnvidia-ml.so.1
+install: $(TARGET)
 	$(INSTALL) -Dm755 $(^) $(libdir)/$(^)
 

--- a/README.md
+++ b/README.md
@@ -22,29 +22,31 @@ the device is in fact supported, and returns information properly.
 How to use
 ----------
 The Makefile can be used to build shims for a given NVML version with `make TARGET_VER=major.minor`.
-The full *major.minor* value must be specified, so `TARGET_VER=440` isn't sufficient, but
-`TARGET_VER=440.82` is:  
-  * `make TARGET_VER=440.82`  
+The full *major.minor* value must be specified, so `TARGET_VER=450` isn't sufficient, but
+`TARGET_VER=450.57` is:  
+  * `make TARGET_VER=450.57`  
 
-Currently supported versions are: 440.x, 430.x, 418.x, 415.x, 410.x, 396.x, 390.x, 331.x,
+Currently supported versions are: 450.x, 440.x, 430.x, 418.x, 415.x, 410.x, 396.x, 390.x, 331.x,
 325.x (x86_64 and i386), and 319.x (x86_64 and i386), with the latest being the default.  
 
 To install, delete the `libnvidia-ml.so.1` symlink currently in your `libdir` and run
 `make install libdir=/path/to/lib`:  
-  * `sudo make install TARGET_VER=440.82 libdir=/usr/lib/x86_64-linux-gnu`  
+  * `sudo make install TARGET_VER=450.57 libdir=/usr/lib/x86_64-linux-gnu`  
 
 It is necessary to supply `TARGET_VER` during *both* `make` and `make install` if not using the default
 version.  
 
 Some common values for `libdir` are `/usr/lib`, `/usr/lib64` (32-bit and 64-bit rpm-based distros),
-`/usr/lib/i386-linux-gnu`, and `/usr/lib/x86_64-linux-gnu` (32-bit and 64-bit deb-based distros).  
+`/usr/lib/i386-linux-gnu`, `/usr/lib/x86_64-linux-gnu` (32-bit and 64-bit Ubuntu-based distros), and 
+`/usr/lib/i386-linux-gnu/nvidia/current`, `/usr/lib/x86_64-linux-gnu/nvidia/current` 
+(32-bit and 64-bit Debian).  
 
 On Debian-based distros an alternative to deleting the symlink is to use `dpkg-divert` to rename it
 (before running `make install`):  
   * `sudo dpkg-divert --add --local --divert /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1.orig --rename
 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1`  
 
-The current Makefile defaults are `TARGET_VER=440.82 libdir=/usr/lib/x86_64-linux-gnu`.  
+The current Makefile defaults are `TARGET_VER=450.57 libdir=/usr/lib/x86_64-linux-gnu`.  
 
 If you are on a 64-bit system, you can build 32-bit versions with `make CFLAGS=-m32`.  
 

--- a/nvml_fix.c
+++ b/nvml_fix.c
@@ -1,21 +1,23 @@
 #include <dlfcn.h>
 
 #if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
+#define NVML_V3
 #include "nvml_v3.h"
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440)
+#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440) || defined(NVML_PATCH_450)
+#define NVML_V9
 #include "nvml_v9.h"
 #else
-#error "No valid NVML_PATCH_* option specified! Currently supported versions are: 440.x, 430.x, 418.x, 415.x, 410.x, 396.x, 390.x, 331.x, 325.x (x86_64 and i386), and 319.x (x86_64 and i386)."
+#error "No valid NVML_PATCH_* option specified! Currently supported versions are: 450.x, 440.x, 430.x, 418.x, 415.x, 410.x, 396.x, 390.x, 331.x, 325.x (x86_64 and i386), and 319.x (x86_64 and i386)."
 #endif
 
 #define FUNC(f) static typeof(f) * real_##f;
 #define FUNC_v2(f) static typeof(f) * real_##f##_v2;
 
-#if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
+#if defined(NVML_V3)
 FUNC(nvmlInit)
 FUNC(nvmlDeviceGetHandleByIndex)
 FUNC(nvmlDeviceGetHandleByPciBusId)
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440)
+#elif defined(NVML_V9)
 FUNC(nvmlInitWithFlags);
 #endif
 FUNC_v2(nvmlInit)
@@ -25,7 +27,7 @@ FUNC(nvmlDeviceGetHandleByUUID)
 FUNC_v2(nvmlDeviceGetHandleByPciBusId)
 
 #define LOAD(f) if (!(real_##f = dlsym(nvml, #f))) return NVML_ERROR_UNKNOWN
-#if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
+#if defined(NVML_V3)
 #define INIT(name) nvmlReturn_t name() \
 { \
 	void *nvml = dlopen("libnvidia-ml.so." NVML_VERSION, RTLD_NOW); \
@@ -41,7 +43,7 @@ FUNC_v2(nvmlDeviceGetHandleByPciBusId)
 \
 	return real_##name(); \
 }
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440)
+#elif defined(NVML_V9)
 #define INIT(name) nvmlReturn_t name() \
 { \
 void *nvml = dlopen("libnvidia-ml.so." NVML_VERSION, RTLD_NOW); \
@@ -57,12 +59,12 @@ void *nvml = dlopen("libnvidia-ml.so." NVML_VERSION, RTLD_NOW); \
 }
 #endif
 
-#if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
+#if defined(NVML_V3)
 INIT(nvmlInit)
 #endif
 INIT(nvmlInit_v2)
 
-#if defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440)
+#if defined(NVML_V9)
 nvmlReturn_t nvmlInitWithFlags(unsigned int flags) {
 	void *nvml = dlopen("libnvidia-ml.so." NVML_VERSION, RTLD_NOW);
 
@@ -109,6 +111,13 @@ void fix_unsupported_bug(nvmlDevice_t device)
 	fix[362] = 1;
 	fix[363] = 1;
 # endif
+#elif defined(NVML_PATCH_450)
+# ifdef __i386__
+#  error "No i386 support for this version yet!"
+# else
+	fix[364] = 1;
+	fix[365] = 1;
+# endif
 #endif
 }
 
@@ -128,7 +137,7 @@ nvmlReturn_t nvmlDeviceGetHandleBy##name(type x, nvmlDevice_t *device) \
 	return NVML_SUCCESS; \
 }
 
-#if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
+#if defined(NVML_V3)
 GET_HANDLE_BY(Index, unsigned int)
 GET_HANDLE_BY(PciBusId, const char *)
 #endif


### PR DESCRIPTION
New offsets are required.

This makes a couple tweaks to reduce clutter in nvml_fix.c as well.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>