### PR TITLE
Add support for 450.66

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CFLAGS        =
 # just set TARGET_VER to a valid ver eg. one of:  390.48 325.08 325.15 319.32 319.23
 TARGET_VER    = 450.57
 TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . -f 1)
+TARGET_MINOR := $(shell echo ${TARGET_VER} | cut -d . -f 2)
 TARGET        = libnvidia-ml.so.1
 # change libdir below based on where libnvidia-ml.so.1 resides.
 # some common values are: /usr/lib, /usr/lib64, /usr/lib/i386-linux-gnu, /usr/lib/x86_64-linux-gnu
@@ -33,7 +34,7 @@ ${TARGET:1=${TARGET_VER}}: empty.c
 	${CC} ${CFLAGS} -shared -fPIC -s $(<) -o $(@) 
 
 $(TARGET): ${TARGET:1=${TARGET_VER}}
-	${CC} ${CFLAGS} -Wl,--no-as-needed -shared -fPIC -s -o $(@) -DNVML_PATCH_${TARGET_MAJOR} -DNVML_VERSION=\"$(TARGET_VER)\" $< nvml_fix.c
+	${CC} ${CFLAGS} -Wl,--no-as-needed -shared -fPIC -s -o $(@) -DNVML_PATCH_${TARGET_MAJOR} -DNVML_PATCH_MINOR=${TARGET_MINOR} -DNVML_VERSION=\"$(TARGET_VER)\" $< nvml_fix.c
 
 clean: 
 	rm -f $(TARGET)

--- a/nvml_fix.c
+++ b/nvml_fix.c
@@ -115,8 +115,13 @@ void fix_unsupported_bug(nvmlDevice_t device)
 # ifdef __i386__
 #  error "No i386 support for this version yet!"
 # else
+#  if NVML_PATCH_MINOR >= 66
+	fix[360] = 1;
+	fix[361] = 1;
+#  else
 	fix[364] = 1;
 	fix[365] = 1;
+#  endif
 # endif
 #endif
 }


### PR DESCRIPTION
Strangely, the offsets changed between 450.57 and 450.66. This passes
another define to GCC so that these can be distinguished at compile
time.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>