### PR TITLE
Bump to 470.74

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC            = gcc
 CFLAGS        =
 # just set TARGET_VER to a valid ver eg. one of:  390.48 325.08 325.15 319.32 319.23
-TARGET_VER    = 470.57.02
+TARGET_VER    = 470.74
 TARGET_MAJOR := $(shell echo ${TARGET_VER} | cut -d . -f 1)
 TARGET_MINOR := $(shell echo ${TARGET_VER} | cut -d . -f 2)
 TARGET        = libnvidia-ml.so.1

--- a/README.md
+++ b/README.md
@@ -23,18 +23,19 @@ How to use
 ----------
 The Makefile can be used to build shims for a given NVML version with `make TARGET_VER=major.minor`.
 The full *major.minor* value must be specified, so `TARGET_VER=470` isn't sufficient, but
-`TARGET_VER=470.57.02` is:  
-  * `make TARGET_VER=470.57.02`  
+`TARGET_VER=470.74` is:  
+  * `make TARGET_VER=470.74`  
 
-Currently supported versions are: 470.x, 460.x, 450.x, 440.x, 430.x, 418.x, 415.x, 410.x, 396.x, 390.x,
-331.x, 325.x (x86_64 and i386), and 319.x (x86_64 and i386), with the latest being the default.  
+Currently supported versions are: 470.x, 460.x, 450.x, 440.x, 430.x, 418.x, 415.x, 410.x, 396.x, 
+390.x, 331.x, 325.x (x86_64 and i386), and 319.x (x86_64 and i386), with the latest being the 
+default.  
 
 To install, delete the `libnvidia-ml.so.1` symlink currently in your `libdir` and run
 `make install libdir=/path/to/lib`:  
-  * `sudo make install TARGET_VER=470.57.02 libdir=/usr/lib/x86_64-linux-gnu`  
+  * `sudo make install TARGET_VER=470.74 libdir=/usr/lib/x86_64-linux-gnu`  
 
-It is necessary to supply `TARGET_VER` during *both* `make` and `make install` if not using the default
-version.  
+It is necessary to supply `TARGET_VER` during *both* `make` and `make install` if not using the 
+default version.  
 
 Some common values for `libdir` are `/usr/lib`, `/usr/lib64` (32-bit and 64-bit rpm-based distros),
 `/usr/lib/i386-linux-gnu`, `/usr/lib/x86_64-linux-gnu` (32-bit and 64-bit Ubuntu-based distros), and 
@@ -46,7 +47,7 @@ On Debian-based distros an alternative to deleting the symlink is to use `dpkg-d
   * `sudo dpkg-divert --add --local --divert /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1.orig --rename
 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1`  
 
-The current Makefile defaults are `TARGET_VER=470.57.02 libdir=/usr/lib/x86_64-linux-gnu`.  
+The current Makefile defaults are `TARGET_VER=470.74 libdir=/usr/lib/x86_64-linux-gnu`.  
 
 If you are on a 64-bit system, you can build 32-bit versions with `make CFLAGS=-m32`.  
 

--- a/nvml_fix.c
+++ b/nvml_fix.c
@@ -3,7 +3,7 @@
 #if defined(NVML_PATCH_319) || defined(NVML_PATCH_325) || defined(NVML_PATCH_331)
 #define NVML_V3
 #include "nvml_v3.h"
-#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440) || defined(NVML_PATCH_450) || defined(NVML_PATCH_460)|| defined(NVML_PATCH_470)
+#elif defined(NVML_PATCH_390) || defined(NVML_PATCH_396) || defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440) || defined(NVML_PATCH_450) || defined(NVML_PATCH_460) || defined(NVML_PATCH_470)
 #define NVML_V9
 #include "nvml_v9.h"
 #else
@@ -105,38 +105,22 @@ void fix_unsupported_bug(nvmlDevice_t device)
 	fix[353] = 1;
 # endif
 #elif defined(NVML_PATCH_410) || defined(NVML_PATCH_415) || defined(NVML_PATCH_418) || defined(NVML_PATCH_430) || defined(NVML_PATCH_440)
-# ifdef __i386__
-#  error "No i386 support for this version yet!"
-# else
 	fix[362] = 1;
 	fix[363] = 1;
-# endif
 #elif defined(NVML_PATCH_450)
-# ifdef __i386__
-#  error "No i386 support for this version yet!"
-# else
-#  if NVML_PATCH_MINOR >= 66
+# if NVML_PATCH_MINOR >= 66
 	fix[360] = 1;
 	fix[361] = 1;
-#  else
+# else
 	fix[364] = 1;
 	fix[365] = 1;
-#  endif
 # endif
 #elif defined(NVML_PATCH_460)
-# ifdef __i386__
-#  error "No i386 support for this version yet!"
-# else
 	fix[360] = 1;
 	fix[361] = 1;
-# endif
 #elif defined(NVML_PATCH_470)
-# ifdef __i386__
-#  error "No i386 support for this version yet!"
-# else
 	fix[362] = 1;
 	fix[363] = 1;
-# endif
 #endif
 }
 


### PR DESCRIPTION
Released 2021/09/20.

Also, remove the __i386__ conditionals for drivers newer than 390, which
is the last version supported by NVIDIA for 32-bit x86.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>